### PR TITLE
Ensuring NetworkEvents plugin log playback messages

### DIFF
--- a/oeaudio/core.py
+++ b/oeaudio/core.py
@@ -1,6 +1,7 @@
 # -*- mode: python -*-
 import datetime
 import logging
+import requests
 from typing import Optional
 
 import sounddevice as sd
@@ -194,6 +195,15 @@ class OpenEphysControl:
         self.logfile = None
 
     def start_recording(self, rec_dir, prepend="", append=""):
+        if self.socket is not None:
+            log.debug("Checking for Broadcast option in Network Events node.")
+            proc_req = requests.get("http://localhost:37497/api/processors")
+            proc_contents = proc_req.json()
+            ntwrk_proc = next((proc for proc in proc_contents if proc['name']=='Network Events'), None)
+            assert ntwrk_proc is not None, "Network Events node not detected in open-ephys GUI!"
+            brdcst_param = next((prm for prm in ntwrk_proc if prm['name']=='broadcast_all_messages'), {'value': 0})
+            assert int(brdcst_param['value']) == 1,  "Set Broadcast to ON in Network Events node before recording!"
+
         cmd = f"StartRecord RecDir={rec_dir} PrependText={prepend}_ AppendText=_{append}"
         log.info("open-ephys: starting recording")
         self._send(cmd, "StartedRecording")

--- a/oeaudio/core.py
+++ b/oeaudio/core.py
@@ -200,9 +200,11 @@ class OpenEphysControl:
             proc_req = requests.get("http://localhost:37497/api/processors")
             proc_contents = proc_req.json()
             ntwrk_proc = next((proc for proc in proc_contents if proc['name']=='Network Events'), None)
-            assert ntwrk_proc is not None, "Network Events node not detected in open-ephys GUI!"
+            if ntwrk_proc is None:
+                raise RuntimeError("NetworkEvents node not detected in open-ephys GUI.")
             brdcst_param = next((prm for prm in ntwrk_proc if prm['name']=='broadcast_all_messages'), {'value': 0})
-            assert int(brdcst_param['value']) == 1,  "Set Broadcast to ON in Network Events node before recording!"
+            if int(brdcst_param['value']) != 1:
+                raise RuntimeError("Set Broadcast to ON in Network Events node before recording!")
 
         cmd = f"StartRecord RecDir={rec_dir} PrependText={prepend}_ AppendText=_{append}"
         log.info("open-ephys: starting recording")

--- a/oeaudio/core.py
+++ b/oeaudio/core.py
@@ -194,7 +194,7 @@ class OpenEphysControl:
         self.logfile = None
 
     def start_recording(self, rec_dir, prepend="", append=""):
-        cmd = f"StartRecord RecDir={rec_dir} PrependText={prepend} AppendText={append}"
+        cmd = f"StartRecord RecDir={rec_dir} PrependText={prepend}_ AppendText=_{append}"
         log.info("open-ephys: starting recording")
         self._send(cmd, "StartedRecording")
         rec_path = self._send("GetRecordingPath")


### PR DESCRIPTION
1. Added separators to prepend and append texts to mimic prior recording directory naming convention.
2. There are two options that needs to be enabled in open-ephys GUI prior to recording: a) enabling the "Broadcast" option in the NetworkEvents node and b) enabling "Force create new directory for each recording". Both of these options cannot be set using the http server protocol (nor NetworkEvents' ZMQ protocol), and it's unclear if these settings will persist through GUI/system restarts. I've added minor http code to check whether Broadcast is enabled if oeaudio-present is not running in dummy mode.